### PR TITLE
require node 16 due to adapter-code 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/TA2k/ioBroker.lg-thinq"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "aws-iot-device-sdk": "^2.2.13",


### PR DESCRIPTION
Adapetr code 3.x.x is known to fail when installed at node 14 oder lower. So this adapter requires node 16 minimum.